### PR TITLE
convert docs to use verb

### DIFF
--- a/.verbrc.md
+++ b/.verbrc.md
@@ -1,6 +1,6 @@
-# boilerplate-bootstrap [![NPM version](https://badge.fury.io/js/boilerplate-bootstrap.png)](http://badge.fury.io/js/boilerplate-bootstrap)
+# {%= name %} {%= badge("fury") %}
 
-> Build Bootstrap with Assemble instead of Jekyll.
+> {%= description %}
 
 #### [See it live →](http://assemble.github.io/boilerplate-bootstrap/)
 
@@ -66,11 +66,7 @@ Take a look at [_config.yml](./_config.yml) to see some of the metadata and conf
 
 ## Author
 
-
-**Jon Schlinkert**
-
-+ [github/jonschlinkert](https://github.com/jonschlinkert)
-+ [twitter/jonschlinkert](http://twitter.com/jonschlinkert)
+{%= contrib("jon") %}
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -151,6 +151,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-frep');
   grunt.loadNpmTasks('grunt-sync-pkg');
+  grunt.loadNpmTasks('grunt-verb');
 
   // Load local "Subgrunt" task to run Bootstrap's Gruntfile.
   grunt.loadTasks('tasks');

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "grunt-frep": "~0.1.2",
     "grunt-sync-pkg": "~0.1.2",
     "handlebars-helper-prettify": "~0.2.1",
-    "pretty": "~0.1.1"
+    "pretty": "~0.1.1",
+    "grunt-verb": "~0.2.3"
   },
   "keywords": [
     "assemble boilerplate",


### PR DESCRIPTION
Before assemble releases v0.5.0, repos need to use verb for creating README.md.
assemble/assemble#501
